### PR TITLE
CON-4767: add aws_instance_roles to example and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,16 @@ In addition to these resources, the newly created service account will have the 
 
 ```hcl
 module "gcr-config" {
-  source            = "uptycslabs/gcr-config/google"
+  source = "uptycslabs/gcr-config/google"
   
-  uptycs_aws_account_id = "Copy/Paste From the Uptycs UI"
-  gcp_project_id        = "Your GCP Project ID"
-  service_account_name  = "uptycs-gcr-integration"
+  uptycs_aws_account_id     = "Copy/Paste From the Uptycs UI"
+  uptycs_aws_instance_roles = ["Copy/Paste From the Uptycs UI"]
+  gcp_project_id            = "Your GCP Project ID"
+  service_account_name      = "uptycs-gcr-integration"
 
   # Copy the AWS Account ID from Uptycs UI
   # Uptycs' UI : "Configurations"->"Registry Configuration"->"ADD REGISTRY"
-  integration_name   = "A unique name for this integration"
+  integration_name = "A unique name for this integration"
 }
 
 ```

--- a/examples/gcr-config/main.tf
+++ b/examples/gcr-config/main.tf
@@ -1,11 +1,12 @@
 module "gcr-config" {
-  source            = "uptycslabs/gcr-config/google"
-  
-  uptycs_aws_account_id = "Copy/Paste From the Uptycs UI"
-  gcp_project_id        = "Your GCP Project ID"
-  service_account_name  = "uptycs-gcr-integration"
+  source = "uptycslabs/gcr-config/google"
+
+  uptycs_aws_account_id     = "Copy/Paste From the Uptycs UI"
+  uptycs_aws_instance_roles = ["Copy/Paste From the Uptycs UI"]
+  gcp_project_id            = "Your GCP Project ID"
+  service_account_name      = "uptycs-gcr-integration"
 
   # Copy the AWS Account ID from Uptycs UI
   # Uptycs' UI : "Configurations"->"Registry Configuration"->"ADD REGISTRY"
-  integration_name   = "A unique name for this integration"
+  integration_name = "A unique name for this integration"
 }


### PR DESCRIPTION
Updates the README and example to demonstrate how to set the `uptycs_aws_instance_roles` variable.