### PR TITLE
make legacy GCR integration optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This terraform module will create the following resources:
 In addition to these resources, the newly created service account will have the following roles attached to it:
 - roles/artifactregistry.reader
 - roles/iam.serviceAccountTokenCreator
+If gcr_integration is true, the following role will also be attached:
 - roles/storage.objectViewer
 
 ## Prerequisites
@@ -53,6 +54,7 @@ module "gcr-config" {
 | integration_name          | A unique name for this GCP - uptycs integration                          | `string` | Yes      |
 | service_account_name      | The name of the GCP service account to use for authentication            | `string` |          |
 | service_account_exists    | A boolean value indicating whether the service account already exists    | `bool`   |          |
+| gcr_integration           | Enable legacy GCR integration (default false)                            | `bool`   |          |
 
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -56,6 +56,7 @@ resource "google_project_iam_member" "bind_iam_service_account_token_creator" {
 }
 
 resource "google_project_iam_member" "bind_storage_object_viewer" {
+  count     = var.gcr_integration ? 1 : 0
   role    = "roles/storage.objectViewer"
   project = var.gcp_project_id
   member  = var.service_account_exists == false ? "serviceAccount:${google_service_account.uptycs_gcr_integration[0].email}" : "serviceAccount:${data.google_service_account.main_account[0].email}"

--- a/variables.tf
+++ b/variables.tf
@@ -33,3 +33,9 @@ variable "service_account_name" {
   type        = string
   description = "The GCP service account name, If a service account with this name already exists, then be sure to set service_account_exists=true"
 }
+
+variable "gcr_integration" {
+  type        = bool
+  default     = false
+  description = "Set to true to enable legacy GCR integration."
+}


### PR DESCRIPTION
The legacy GCR integration will be disabled by default and can be enabled optionally.