### PR TITLE
Add org level integration for Google Artifact/GCR.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ In addition to these resources, the newly created service account will have the 
 If gcr_integration is true, the following role will also be attached:
 - roles/storage.objectViewer
 
+## Organization-level Integration
+
+If you need to configure GCR monitoring at the organization level (across all projects), use the [organization module](./organization/README.md) instead. The organization module grants IAM roles at the organization level rather than the project level.
+
+The organization module now supports granting permissions to specific projects instead of the entire organization by using the `registry_projects` variable. This allows for more granular control over which projects the service account can access.
+
+
 ## Prerequisites
 
 - Minimum required version of Terraform -> v0.13

--- a/examples/gcr-config-org/main.tf
+++ b/examples/gcr-config-org/main.tf
@@ -1,0 +1,15 @@
+module "gcr-config-org" {
+  source = "../../organization"
+  
+  uptycs_aws_instance_roles = ["Role_Allinone", "Role_PNode"]
+  gcp_host_project_id       = "my-project-123456"
+  org_id                    = "123456789012"
+  service_account_name      = "uptycs-gcr-integration"
+  
+  # From Uptycs UI: "Configurations" -> "Registry Configuration" -> "ADD REGISTRY"
+  uptycs_aws_account_id     = "012345678901"
+  integration_name          = "uptycs-gcr-org-integration"
+  
+  # Enable legacy GCR integration if needed
+  gcr_integration           = false
+}

--- a/organization/README.md
+++ b/organization/README.md
@@ -1,0 +1,95 @@
+# Organization-level GCR Configuration Module
+
+This module creates the necessary GCP resources to grant Uptycs access to artifact registries at the **organization level** for registry monitoring. Access is setup with Workload Identity Pool (WIP) with AWS as the identity provider. This avoids the need to manage sensitive keys.
+
+This terraform module will create the following resources:
+
+- Service account
+- Workload Identity Pool
+- Identity Provider AWS
+
+In addition to these resources, the newly created service account will have the following roles attached **at the organization level**:
+- roles/artifactregistry.reader
+- roles/iam.serviceAccountTokenCreator
+If gcr_integration is true, the following role will also be attached:
+- roles/storage.objectViewer
+
+## Prerequisites
+
+- Minimum required version of Terraform -> v0.13
+- The user must have `Git` installed on the system that they are using to execute the Terraform script.
+  - Instructions on how to install Git here: https://github.com/git-guides/install-git
+- The user must also have the `gcloud` CLI installed and authenticated as described in both the [Terraform](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/getting_started#configuring-the-provider) and [GCP](https://cloud.google.com/sdk/gcloud) documentation.
+- Organization-level IAM permissions to grant roles at the organization level
+
+## Running the Terraform Module
+
+- Create a file with name as `main.tf` and paste the code given below into it.
+
+```hcl
+module "gcr-config-org" {
+  source = "uptycslabs/gcr-config/google//organization"
+  
+  uptycs_aws_instance_roles = ["Copy/Paste From the Uptycs UI"]
+  gcp_host_project_id       = "Your GCP Project ID where the service account will be created"
+  org_id                    = "Your GCP Organization ID"
+  service_account_name      = "uptycs-gcr-integration"
+
+  # Copy the AWS Account ID from Uptycs UI
+  # Uptycs' UI : "Configurations"->"Registry Configuration"->"ADD REGISTRY"
+  uptycs_aws_account_id     = "Copy/Paste From the Uptycs UI"
+
+  integration_name = "A unique name for this integration"
+}
+```
+
+- Modify the 'Input' details as needed
+- `uptycs_aws_account_id` must be copied from the Uptycs UI.
+
+## Inputs
+
+| Name                      | Description                                                              | Type     | Required |
+| ------------------------  | ------------------------------------------------------------------------ | -------- | -------- |
+| uptycs_aws_account_id     | AWS account id of Uptycs                                                 | `string` | Yes      |
+| uptycs_aws_instance_roles | Instances roles to be specified as the Workload Identity Binding members | `array`  | Yes      |
+| gcp_host_project_id       | The GCP project ID where the service account and workload identity pool will be created | `string` | Yes      |
+| org_id                    | The GCP organization ID where resources will be managed                  | `string` | Yes      |
+| integration_name          | A unique name for this GCP - Uptycs integration                          | `string` | Yes      |
+| service_account_name      | The name of the GCP service account to use for authentication            | `string` | Yes      |
+| service_account_exists    | A boolean value indicating whether the service account already exists    | `bool`   | No       |
+| gcr_integration           | Enable legacy GCR integration (default false)                            | `bool`   | No       |
+
+
+## Outputs
+
+This module produces no terraform outputs, however, successfully running this module will result in a `credentials.json` file being generated in your working directory.
+
+## GCP Authentication
+
+Prior to executing this module, ensure that you are locally authenticated to GCP.
+
+```sh
+gcloud auth application-default login
+```
+
+## Execute Terraform Script to Generate `credentials.json`
+
+```sh
+$ terraform init -upgrade
+$ terraform plan
+$ terraform apply
+```
+
+## Organization vs Project Level Integration
+
+This module differs from the base module in the following ways:
+
+1. It grants IAM roles at the **organization level**
+2. It provides organization-wide access to artifact registries
+
+Use this module when you need to monitor artifact registries across your entire GCP organization.
+
+### Service Account Location
+
+The service account and workload identity pool are created in the project specified by `gcp_host_project_id`, while the permissions are granted at the organization level. This allows you to have a single service account that has access to the entire organization.
+

--- a/organization/main.tf
+++ b/organization/main.tf
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2025 Uptycs, Inc. All rights reserved
+ */
+
+data "google_service_account" "main_account" {
+  count      = var.service_account_exists ? 1 : 0
+  account_id = var.service_account_name
+  project    = var.gcp_host_project_id
+}
+
+data "google_project" "main_project" {
+  project_id = var.gcp_host_project_id
+}
+
+resource "google_iam_workload_identity_pool" "create_wip" {
+  provider                  = google-beta
+  project                   = var.gcp_host_project_id
+  workload_identity_pool_id = "wip-${var.integration_name}"
+  display_name              = "wip-${var.integration_name}"
+  description               = "Workload Identity Pool to allow Uptycs integration via AWS federation"
+  disabled                  = false
+}
+
+resource "google_iam_workload_identity_pool_provider" "add_provider" {
+  provider                           = google-beta
+  project                            = var.gcp_host_project_id
+  workload_identity_pool_id          = google_iam_workload_identity_pool.create_wip.workload_identity_pool_id
+  workload_identity_pool_provider_id = "idp-${var.integration_name}"
+  aws {
+    account_id = var.uptycs_aws_account_id
+  }
+}
+
+resource "google_service_account" "uptycs_gcr_integration" {
+  count        = var.service_account_exists ? 0 : 1
+  project      = var.gcp_host_project_id
+  account_id   = var.service_account_name
+  display_name = var.service_account_name
+  description  = "Uptycs GCR Service Account Intergration"
+}
+
+resource "google_service_account_key" "uptycs_gcr_integration_key" {
+  service_account_id = var.service_account_exists == false ? google_service_account.uptycs_gcr_integration[0].name : data.google_service_account.main_account[0].name
+}
+
+resource "google_organization_iam_member" "bind_artifact_registry_reader" {
+  org_id =  var.org_id  
+  role    = "roles/artifactregistry.reader"
+  member  = var.service_account_exists == false ? "serviceAccount:${google_service_account.uptycs_gcr_integration[0].email}" : "serviceAccount:${data.google_service_account.main_account[0].email}"
+}
+
+resource "google_organization_iam_member" "bind_iam_service_account_token_creator" {
+  org_id =  var.org_id
+  role    = "roles/iam.serviceAccountTokenCreator"
+  member  = var.service_account_exists == false ? "serviceAccount:${google_service_account.uptycs_gcr_integration[0].email}" : "serviceAccount:${data.google_service_account.main_account[0].email}"
+}
+
+resource "google_organization_iam_member" "bind_storage_object_viewer" {
+  count     = var.gcr_integration ? 1 : 0
+  org_id =  var.org_id
+  role    = "roles/storage.objectViewer"
+  member  = var.service_account_exists == false ? "serviceAccount:${google_service_account.uptycs_gcr_integration[0].email}" : "serviceAccount:${data.google_service_account.main_account[0].email}"
+}
+
+resource "google_service_account_iam_binding" "workload_identity_binding" {
+  service_account_id = var.service_account_exists == false ? "${google_service_account.uptycs_gcr_integration[0].name}" : "${data.google_service_account.main_account[0].name}"
+  role               = "roles/iam.workloadIdentityUser"
+  members = [for each in var.uptycs_aws_instance_roles : format("principalSet://iam.googleapis.com/projects/%s/locations/global/workloadIdentityPools/%s/attribute.aws_role/arn:aws:sts::%s:assumed-role/%s", data.google_project.main_project.number,google_iam_workload_identity_pool.create_wip.workload_identity_pool_id,var.uptycs_aws_account_id, each)]
+}
+
+resource "null_resource" "cred_config_json" {
+  provisioner "local-exec" {
+    command     = "gcloud iam workload-identity-pools create-cred-config projects/${data.google_project.main_project.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.create_wip.workload_identity_pool_id}/providers/${google_iam_workload_identity_pool_provider.add_provider.workload_identity_pool_provider_id} --service-account=${var.service_account_exists == false ? google_service_account.uptycs_gcr_integration[0].email : data.google_service_account.main_account[0].email} --output-file=credentials.json --aws"
+    interpreter = ["/bin/sh", "-c"]
+  }
+}

--- a/organization/main.tf
+++ b/organization/main.tf
@@ -39,10 +39,6 @@ resource "google_service_account" "uptycs_gcr_integration" {
   description  = "Uptycs GCR Service Account Intergration"
 }
 
-resource "google_service_account_key" "uptycs_gcr_integration_key" {
-  service_account_id = var.service_account_exists == false ? google_service_account.uptycs_gcr_integration[0].name : data.google_service_account.main_account[0].name
-}
-
 resource "google_organization_iam_member" "bind_artifact_registry_reader" {
   org_id =  var.org_id  
   role    = "roles/artifactregistry.reader"

--- a/organization/outputs.tf
+++ b/organization/outputs.tf
@@ -1,0 +1,3 @@
+/*
+ * Copyright (c) 2023 Uptycs, Inc. All rights reserved
+ */

--- a/organization/providers.tf
+++ b/organization/providers.tf
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2023 Uptycs, Inc. All rights reserved
+ */
+
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.53.1"
+    }
+  }
+
+  provider_meta "google" {
+    module_name = "blueprints/terraform/terraform-google-iam-config/v1.0.0"
+  }
+}

--- a/organization/variables.tf
+++ b/organization/variables.tf
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023 Uptycs, Inc. All rights reserved
+ */
+
+variable uptycs_aws_account_id {
+    description = "Aws account id of Uptycs - for federated identity"
+    type = string
+}
+
+variable "uptycs_aws_instance_roles" {
+  type        = list 
+  description = "AWS role names of Uptycs - for identity binding"
+  default     = ["Role_Allinone", "Role_PNode"]
+}
+
+variable integration_name {
+    description = "ExternalId to be used for API authentication."
+    type = string
+}
+
+variable "gcp_host_project_id" {
+  type        = string
+  description = "The GCP project ID where the service account and workload identity pool will be created"
+}
+
+variable "service_account_exists" {
+  type        = bool
+  description = "Set to true if service account already exists."
+  default     = false
+}
+
+variable "service_account_name" {
+  type        = string
+  description = "The GCP service account name, If a service account with this name already exists, then be sure to set service_account_exists=true"
+}
+
+variable "gcr_integration" {
+  type        = bool
+  default     = false
+  description = "Set to true to enable legacy GCR integration."
+}
+
+variable "org_id" {
+  type        = string
+  description = "The GCP organization ID where resources will be managed"
+}


### PR DESCRIPTION
This module now supports org-level integration. It will unconditionally scan all the images in the entire organization. There is no exclusions yet.
